### PR TITLE
gaepypi: properly handle multiple colons in user/pw

### DIFF
--- a/gaepypi/_decorators.py
+++ b/gaepypi/_decorators.py
@@ -28,7 +28,10 @@ def basic_auth(func):
         if auth_header is None:
             __basic_login(handler)
         else:
-            (username, password) = base64.b64decode(auth_header.split(' ')[1]).split(':')
+            parts = base64.b64decode(auth_header.split(' ')[1]).split(':')
+            username = parts[0]
+            password = ':'.join(parts[1:])
+
             if __basic_lookup(username) == __basic_hash(password):
                 return func(handler, *args, **kwargs)
             else:


### PR DESCRIPTION
The username *may not* contain colons and the password *may*. Thus the
part before the first colon is considered the username, and everything
else after it is the password. This makes GAEPyPI support basic auth as
outlined in RFC 7617.