### PR TITLE
Fix handling of prefixed package name.

### DIFF
--- a/gaepypi/_handlers.py
+++ b/gaepypi/_handlers.py
@@ -136,6 +136,7 @@ class PackageList(BaseHandler):
         index = PackageIndex(self.get_storage(), package)
         if not index.exists():
             self.write404()
+            return
         self.write_page(index.to_html(full_index=False))
 
 

--- a/gaepypi/storage.py
+++ b/gaepypi/storage.py
@@ -151,8 +151,9 @@ class GCStorage(Storage):
         gcs_file.close()
 
     def file_exists(self, path):
-        match = list(gcs.listbucket(path.rstrip('/'), delimiter='/'))
-        return len(match) == 1 and not match[0].is_dir
+        match = list(gcs.listbucket(path.rstrip('/')))
+        return path.rstrip('/') in [stat.filename for stat in match]
 
     def path_exists(self, path):
-        return len(list(gcs.listbucket(path.rstrip('/'), delimiter='/'))) == 1
+        match = list(gcs.listbucket(path.rstrip('/'), delimiter='/'))
+        return path.rstrip('/') in [stat.filename.rstrip('/') for stat in match]


### PR DESCRIPTION
As of now GAEPyPI breaks when a package name prefixes another package (e.g. we have a `package_a` and a `package_a_prefix`). This is due to the way the _Google_ Storage lib function `listbucket` handles such cases when listing the content of a GCS bucket.
