### PR TITLE
Added Roles for User Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This application runs on Google App Engine (and uses webapp2 instead of tornado)
 2. Downloading by package (or package and version)
 3. A / page that is navigatable with a web browser
 4. /pypi/ listing
-5. Basic ACL through http auth
+5. Basic ACL through http auth with optional account roles (read/write)
 6. Prevent overwriting a package with the same name & version
 
 Unsupported are: 

--- a/config.json
+++ b/config.json
@@ -1,8 +1,13 @@
 {
   "accounts": [
     {
-      "username": "user",
+      "username": "read_only_user",
       "password": "password"
+    },
+    {
+      "username": "read_write_user",
+      "password": "password",
+      "roles": ["write"]
     }
   ]
 }

--- a/gaepypi/_decorators.py
+++ b/gaepypi/_decorators.py
@@ -16,28 +16,39 @@
 
 import base64
 import json
+from functools import wraps
 from webapp2_extras import security
 
 
-def basic_auth(func):
+def basic_auth(required_roles=None):
     """
     Decorator to require HTTP auth for request handler
     """
-    def callf(handler, *args, **kwargs):
-        auth_header = handler.request.headers.get('Authorization')
-        if auth_header is None:
-            __basic_login(handler)
-        else:
-            parts = base64.b64decode(auth_header.split(' ')[1]).split(':')
-            username = parts[0]
-            password = ':'.join(parts[1:])
-
-            if __basic_lookup(username) == __basic_hash(password):
-                return func(handler, *args, **kwargs)
-            else:
+    def decorator_basic_auth(func):
+        def callf(handler, *args, **kwargs):
+            auth_header = handler.request.headers.get('Authorization')
+            if auth_header is None:
                 __basic_login(handler)
+            else:
+                parts = base64.b64decode(auth_header.split(' ')[1]).split(':')
+                username = parts[0]
+                password = ':'.join(parts[1:])
+                account = __basic_lookup(username)
 
-    return callf
+                # Return 401 Unauthorized if user did not specify credentials or password is mismatched
+                if not account or account["password"] != __basic_hash(password):
+                    return __basic_login(handler)
+
+                # Return 403 Forbidden if user's account does not have any of the required access roles
+                user_roles = account['roles'] if 'roles' in account else []
+                if required_roles and any([(required_role not in user_roles) for required_role in required_roles]):
+                    return __basic_forbidden(handler)
+
+                else:
+                    return func(handler, *args, **kwargs)
+
+        return callf
+    return decorator_basic_auth
 
 
 def __basic_login(handler):
@@ -45,12 +56,16 @@ def __basic_login(handler):
     handler.response.headers['WWW-Authenticate'] = 'Basic realm="Secure Area"'
 
 
+def __basic_forbidden(handler):
+    handler.response.set_status(403, message="Forbidden")
+
+
 def __basic_lookup(username):
     with open('config.json') as data_file:
         config = json.load(data_file)
     for account in config["accounts"]:
         if account['username'] == username:
-            return account['password']
+            return account
 
 
 def __basic_hash(password):

--- a/gaepypi/_handlers.py
+++ b/gaepypi/_handlers.py
@@ -48,11 +48,11 @@ class IndexHandler(BaseHandler):
     Handles /
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self):
         self.write_page('<a href="/packages">packages</a>')
 
-    @basic_auth
+    @basic_auth(required_roles=['write'])
     def post(self):
         name = self.request.get('name', default_value=None)
         version = self.request.get('version', default_value=None)
@@ -75,7 +75,7 @@ class PypiHandler(BaseHandler):
     Handles /pypi/
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self):
         self.write_page(self.get_storage().to_html(full_index=True))
 
@@ -85,7 +85,7 @@ class PypiPackageHandler(BaseHandler):
     Handles /pypi/package
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self, package):
         storage = self.get_storage()
         index = PackageIndex(storage, package)
@@ -102,7 +102,7 @@ class PackageVersionHandler(BaseHandler):
        - /packages/package/version
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self, package, version):
         package = Package(self.get_storage(), package, version)
         if not package.exists():
@@ -116,7 +116,7 @@ class PackageBase(BaseHandler):
     Handles /packages
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self):
         storage = self.get_storage()
         if storage.empty():
@@ -131,7 +131,7 @@ class PackageList(BaseHandler):
     Handles /packages/package
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self, package):
         index = PackageIndex(self.get_storage(), package)
         if not index.exists():
@@ -144,7 +144,7 @@ class PackageDownload(BaseHandler):
     Handles /packages/package/version/filename
     """
 
-    @basic_auth
+    @basic_auth()
     def get(self, name, version, filename):
         try:
             package = Package(self.get_storage(), name, version)


### PR DESCRIPTION
Added the ability for each server endpoint secured with the `@basic_auth` decorator to support required roles to execute that endpoint.  The corresponding roles can be granted (optionally) to any user account in the `config.json` file.  If any endpoint has required roles defined, they are checked against the user account's set of roles to ensure all are present, otherwise a `403 Forbidden` response is returned.

This change is intended to facilitate the creation of separate user accounts with read-only vs. read/write privileges so that users with the read-only role (the default) cannot commit their own packages.  The `post()` endpoint used to write packages to GCS has therefore been protected with `required_roles=['write']` ensuring the user must be authenticated with an account containing the `write` role in order to commit packages.